### PR TITLE
Obsoleted _TASK_ROLLOVER_FIX

### DIFF
--- a/src/TaskScheduler.h
+++ b/src/TaskScheduler.h
@@ -620,27 +620,9 @@ void Scheduler::execute() {
 				}
 	#endif
 				p = iCurrent->iPreviousMillis;
-
-	// Determine when current task is supposed to run
-	// Once every 47 days there is a rollover execution which will occur due to millis and targetMillis rollovers
-	// That is why there is an option to compile with rollover fix
-	// Example
-	//	iPreviousMillis = 65000
-	//	iInterval = 600
-	//	millis() = 65500
-	//  targetMillis = 65000 + 600 = (should be 65600) 65 (due to rollover)
-	//	so 65 < 65500. should be 65600 > 65500. - task will be scheduled incorrectly
-	//  since targetMillis (65) < iPreviousMillis (65000), rollover fix kicks in:
-	//  iPreviousMillis(65000) > millis(65500) - iInterval(600) = 64900 - task will not be scheduled
-	
+				
 				targetMillis = p + i;
-	#ifdef _TASK_ROLLOVER_FIX
-				if ( targetMillis < p ) {  // targetMillis rolled over!
-					if ( p > ( m - i) )  break;
-				}
-				else
-	#endif
-					if ( targetMillis > m ) break;
+				if ( m - p < i ) break;
 	
 	#ifdef _TASK_TIMECRITICAL
 	// Updated_previous+current interval should put us into the future, so iOverrun should be positive or zero. 


### PR DESCRIPTION
Based upon http://arduino.stackexchange.com/a/12588/10648, the extra
code for _TASK_ROLLOVER_FIX should not be needed if the math is done
slightly different. I updated the code and did some quick tests and it
appears correct. Example #6 returns the same values for IDLE, but a few
less ms when not compiled with IDLE. Using the setMillis() function in
the SO posting, I did some quick tests with Example #2. using
setMillis(-3000) sets the millis() value to 3 seconds before rollover.
Task #1 gets an extra catch-up hit, but not Task #2. But, it works the
same as the original code though when using setMillis(-3000).

Let me know if you have questions.