### PR TITLE
Adding optional support for std::function

### DIFF
--- a/src/TaskScheduler.h
+++ b/src/TaskScheduler.h
@@ -124,6 +124,7 @@
  *  #define _TASK_LTS_POINTER       // Compile with support for local task storage pointer
  *  #define _TASK_PRIORITY			// Support for layered scheduling priority
  *  #define _TASK_MICRO_RES			// Support for microsecond resolution
+ *  #define _TASK_STD_FUNCTION      // Support for std::function
  */
 
 
@@ -197,9 +198,17 @@ class StatusRequest {
 };
 #endif  // _TASK_STATUS_REQUEST
 
+#ifdef _TASK_STD_FUNCTION
+#define _TASK_STD_FUNCTION
+#include <functional>
+typedef std::function<void()> callback_t;
+typedef std::function<void()> onDisable_cb_t;
+typedef std::function<bool()> onEnable_cb_t;
+#else
 typedef void (*callback_t)();
 typedef void (*onDisable_cb_t)();
 typedef bool (*onEnable_cb_t)();
+#endif
 
 typedef struct  {
 	bool enabled : 1;							// indicates that task is enabled or not.


### PR DESCRIPTION
Adding support for std::function. The pull request consist of 2 commits. The first one introduces typedefs for the different callbacks. I feel this would be a useful addition in any case.

The second commit adds __optional__ support for `std::function`

Support is enabled by adding: 
```C++
#define _TASK_STD_FUNCTION
```

As discussed in #28 enabling this does add a slight overhead. I ran the benchmark example and without _TASK_STD_FUNCTION defined the duration was: 
```
Start...done.
Tstart =17039
Tfinish=33052
Duration=16013
```

with `#define _TASK_STD_FUNCTION` it changes to:
```
Start...done.
Tstart =17156
Tfinish=33574
Duration=16418
``` 