### PR TITLE
Add support for bare-metal AVR

### DIFF
--- a/README
+++ b/README
@@ -4,6 +4,12 @@ Version 2.5.0: 2017-08-30
 If you find TaskScheduler useful for your Arduino project, please drop me an email: arkhipenko@hotmail.com
 ----------------------------------------------------------------------------------------------------------
 
+FORK:
+
+This is a fork of the main TaskScheduler repo. It adds some small changes to support use with bare metal code outside of the Arduino environment. It has only been tested on AVR devices.
+
+This library only depends on the Arduino millis() or micros() functions. You can use third-party libraries like Zak Kemble's millis lib (https://github.com/zkemble/millis) or write your own replacement. The ESP8266 target also requires a substitute for yield() and delay().
+
 OVERVIEW:
  A lightweight implementation of cooperative multitasking (task scheduling) supporting:
  1. Periodic task execution (with dynamic execution period in milliseconds or microseconds)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 ### Cooperative multitasking for Arduino microcontrollers  
 #### Version 2.5.0: 2017-08-30
 
+### FORK:
+
+This is a fork of the main TaskScheduler repo. It adds some small changes to support use with bare metal code outside of the Arduino environment. It has only been tested on AVR devices.
+
+This library only depends on the Arduino millis() or micros() functions. You can use third-party libraries like Zak Kemble's millis lib (https://github.com/zkemble/millis) or write your own replacement. The ESP8266 target also requires a substitute for yield() and delay().
+
+
 ### OVERVIEW:
 A lightweight implementation of cooperative multitasking (task scheduling) supporting:  
 1. Periodic task execution, with dynamic execution period in `milliseconds` (default) or `microseconds` (if explicitly enabled) – frequency of execution  

--- a/src/TaskScheduler.h
+++ b/src/TaskScheduler.h
@@ -120,12 +120,40 @@
 //    2017-08-30 - bug fix: Scheduler::addTask() checks if task is already part of an execution chain (github issue #37)
 //    2017-08-30 - support for multi-tab sketches (Contributed by Adam Ryczkowski - https://github.com/adamryczkowski)
 
-
-#include <Arduino.h>
-#include "TaskSchedulerDeclarations.h"
-
 #ifndef _TASKSCHEDULER_H_
 #define _TASKSCHEDULER_H_
+
+#if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+#  include "Arduino.h"
+
+#else // Not in Arduino environment
+
+// Detect target arch
+#  if !defined(ARDUINO_ARCH_AVR) && defined(__AVR__)
+#    define ARDUINO_ARCH_AVR 1
+#  endif
+
+
+// NOTE: You must supply one of these functions depending on _TASK_MICRO_RES
+//       ESP8266 requires micros(), delay(), and yield().
+#  if defined(_TASK_MICRO_RES) || defined(ARDUINO_ARCH_ESP8266)
+extern unsigned long micros(void);
+#  endif
+extern unsigned long millis(void);
+
+#  if defined(ARDUINO_ARCH_ESP8266)
+extern void yield(void);
+extern void delay(unsigned long);
+#  endif
+
+#  if !(defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32))
+#    error Missing ARDUINO_ARCH_* definition.
+#  endif
+
+#endif // ARDUINO_ARCH_*
+
+#include "TaskSchedulerDeclarations.h"
+
 
 // ----------------------------------------
 // The following "defines" control library functionality at compile time,

--- a/src/TaskSchedulerDeclarations.h
+++ b/src/TaskSchedulerDeclarations.h
@@ -1,7 +1,8 @@
 // Cooperative multitasking library for Arduino
 // Copyright (c) 2015-2017 Anatoli Arkhipenko
 
-#include <stddef.h> 
+#include <stddef.h>
+#include <stdint.h>
 
 #ifndef _TASKSCHEDULERDECLARATIONS_H_
 #define _TASKSCHEDULERDECLARATIONS_H_
@@ -90,7 +91,7 @@ typedef struct  {
     bool  enabled    : 1;           // indicates that task is enabled or not.
     bool  inonenable : 1;           // indicates that task execution is inside OnEnable method (preventing infinite loops)
 #ifdef _TASK_STATUS_REQUEST
-    byte  waiting    : 2;           // indication if task is waiting on the status request
+    uint8_t  waiting : 2;           // indication if task is waiting on the status request
 #endif
 } __task_status;
 


### PR DESCRIPTION
I've added some changes to support using TaskScheduler on bare-metal AVR without the Arduino support libraries. Additional minor work is needed to do the same for ESP8266 and ESP32.