### PR TITLE
Added Scheduler::executeBacklog(size_t noTasks)

### DIFF
--- a/src/TaskScheduler.h
+++ b/src/TaskScheduler.h
@@ -925,6 +925,17 @@ bool Scheduler::execute() {
     return (idleRun);
 }
 
-
+/** Execute upto the given noTasks from the backlog  
+ */
+bool Scheduler::executeBacklog(size_t noTasks) {
+    size_t i = 0;
+    // Run till scheduler is idle (or we executed a max no. tasks)
+    auto idle = this->execute();
+    while (i < noTasks && !idle) {
+        idle = this->execute();
+        ++i;
+    }
+    return idle;
+}
 
 #endif /* _TASKSCHEDULER_H_ */

--- a/src/TaskSchedulerDeclarations.h
+++ b/src/TaskSchedulerDeclarations.h
@@ -242,6 +242,7 @@ class Scheduler {
     INLINE void disableAll(bool aRecursive = true);
     INLINE void enableAll(bool aRecursive = true);
     INLINE bool execute();                              // Returns true if none of the tasks' callback methods was invoked (true = idle run)
+    INLINE bool executeBacklog(size_t noTasks = 10);
     INLINE void startNow(bool aRecursive = true);       // reset ALL active tasks to immediate execution NOW.
     INLINE Task& currentTask() ;
     INLINE long timeUntilNextIteration(Task& aTask);    // return number of ms until next iteration of a given Task


### PR DESCRIPTION
This method executes upto the given noTasks from the backlog. 

It's a helper function to make it easier to empty the backlog in the queue