### PR TITLE
Add guard to _TASK_SCOPE, so it can be configured externally

### DIFF
--- a/src/TaskSchedulerDeclarations.h
+++ b/src/TaskSchedulerDeclarations.h
@@ -24,11 +24,13 @@
 // #define _TASK_TIMEOUT           // Support for overall task timeout
 // #define _TASK_OO_CALLBACKS      // Support for dynamic callback method binding
 
+#ifndef _TASK_SCOPE
 #ifdef _TASK_DEBUG
     #define _TASK_SCOPE  public
 #else
     #define _TASK_SCOPE  private
 #endif
+#endif // _TASK_SCOPE
 
 #define TASK_IMMEDIATE          0
 #define TASK_FOREVER         (-1)


### PR DESCRIPTION
Need access to internals when deriving from OO style task, so I'm defining _TASK_SCOPE as protected, but it would be redefined in TaskSchedulerDeclarations.h.

Adding a guard would be great.