### PR TITLE
feature: allow std::function for STM32

### DIFF
--- a/src/TaskScheduler.h
+++ b/src/TaskScheduler.h
@@ -234,9 +234,9 @@ extern "C" {
 #endif  // _TASK_SLEEP_ON_IDLE_RUN
 
 
-#if !defined (ARDUINO_ARCH_ESP8266) && !defined (ARDUINO_ARCH_ESP32)
+#if !defined (ARDUINO_ARCH_ESP8266) && !defined (ARDUINO_ARCH_ESP32) && !defined (ARDUINO_ARCH_STM32)
 #ifdef _TASK_STD_FUNCTION
-    #error Support for std::function only for ESP8266 or ESP32 architecture
+    #error Support for std::function only for ESP8266, ESP32, STM32 architecture
 #undef _TASK_STD_FUNCTION
 #endif // _TASK_STD_FUNCTION
 #endif // ARDUINO_ARCH_ESP8266
@@ -1086,7 +1086,7 @@ bool Scheduler::execute() {
         iCPUCycle += ( (micros() - tPassStart) - (tTaskFinish - tTaskStart) );
 #endif  // _TASK_TIMECRITICAL
         
-#if defined (ARDUINO_ARCH_ESP8266) || defined (ARDUINO_ARCH_ESP32)
+#if defined (ARDUINO_ARCH_ESP8266) || defined (ARDUINO_ARCH_ESP32) || defined (ARDUINO_ARCH_STM32)
         yield();
 #endif  // ARDUINO_ARCH_ESPxx
     }


### PR DESCRIPTION
naive poking showed that std::function works for stm32

<img width="500" alt="Screenshot 2020-10-01 at 12 50 08" src="https://user-images.githubusercontent.com/95058/94794512-a58f7080-03e4-11eb-887f-f361e46744f1.png">
