### PR TITLE
isolate _task_micros()

### DIFF
--- a/src/TaskScheduler.h
+++ b/src/TaskScheduler.h
@@ -276,10 +276,13 @@ extern "C" {
 // ------------------ TaskScheduler implementation --------------------
 
 #ifndef _TASK_EXTERNAL_TIME
-static uint32_t _task_millis() {return millis();}
+
 #ifdef _TASK_MICRO_RES
 static uint32_t _task_micros() {return micros();}
+#else
+static uint32_t _task_millis() {return millis();}
 #endif  //  _TASK_MICRO_RES
+
 #endif  //  _TASK_EXTERNAL_TIME
 
 /** Constructor, uses default values for the parameters

--- a/src/TaskScheduler.h
+++ b/src/TaskScheduler.h
@@ -190,7 +190,7 @@
 //                 feature: Task.cancelled() method - indicates that task was disabled with a cancel() method.
 //
 // v3.2.3:
-//    2021-01-01 - feature: discontinued use of 'register' keyword. Depricated in C++ 11 
+//    2021-01-01 - feature: discontinued use of 'register' keyword. Deprecated in C++ 11 
 //                 feature: add STM32 as a platform supporting _TASK_STD_FUNCTION. (PR #105)
 //
 // v3.3.0:
@@ -265,7 +265,7 @@ extern "C" {
 #endif // ARDUINO_ARCH_ESP8266
 
 #ifdef _TASK_WDT_IDS
-    static unsigned int __task_id_counter = 0; // global task ID counter for assiging task IDs automatically.
+    static unsigned int __task_id_counter = 0; // global task ID counter for assigning task IDs automatically.
 #endif  // _TASK_WDT_IDS
 
 #ifdef _TASK_PRIORITY
@@ -366,7 +366,7 @@ StatusRequest* Task::getInternalStatusRequest() { return &iMyStatusRequest; }
 
 /** Signals completion of the StatusRequest by one of the participating events
  *  @param: aStatus - if provided, sets the return code of the StatusRequest: negative = error, 0 (default) = OK, positive = OK with a specific status code
- *  Negative status will complete Status Request fully (since an error occured).
+ *  Negative status will complete Status Request fully (since an error occurred).
  *  @return: true, if StatusRequest is complete, false otherwise (still waiting for other events)
  */
 bool StatusRequest::signal(int aStatus) {
@@ -403,7 +403,7 @@ bool Task::waitForDelayed(StatusRequest* aStatusRequest, unsigned long aInterval
     iStatusRequest = aStatusRequest;
     if ( iStatusRequest != NULL ) { // assign internal StatusRequest var and check if it is not NULL
         setIterations(aIterations);
-        if ( aInterval ) setInterval(aInterval);  // For the dealyed version only set the interval if it was not a zero
+        if ( aInterval ) setInterval(aInterval);  // For the delayed version only set the interval if it was not a zero
         iStatus.waiting = _TASK_SR_DELAY;  // with delay equal to the current interval
         return enable();
     }
@@ -714,7 +714,7 @@ void Task::abort() {
 
 
 /** Cancels task execution
- * Task will no longer be executed by the scheduler. Ondisable method will be called after 'canceled' flag is set
+ * Task will no longer be executed by the scheduler. The ondisable method will be called after 'canceled' flag is set
  */
 void Task::cancel() {
     iStatus.canceled = true;
@@ -789,7 +789,7 @@ Scheduler::~Scheduler() {
 }
 */
 
-/** Initializes all internal varaibles
+/** Initializes all internal variables
  */
 void Scheduler::init() {
     iFirst = NULL;
@@ -982,7 +982,7 @@ long Scheduler::timeUntilNextIteration(Task& aTask) {
 }
 
 
-Task& Scheduler::currentTask() { return *iCurrent; }      // DEPRICATED. Use the next one instead
+Task& Scheduler::currentTask() { return *iCurrent; }      // DEPRECATED. Use the next one instead
 Task* Scheduler::getCurrentTask() { return iCurrent; }
 
 #ifdef _TASK_LTS_POINTER

--- a/src/TaskScheduler.h
+++ b/src/TaskScheduler.h
@@ -277,7 +277,9 @@ extern "C" {
 
 #ifndef _TASK_EXTERNAL_TIME
 static uint32_t _task_millis() {return millis();}
+#ifdef _TASK_MICRO_RES
 static uint32_t _task_micros() {return micros();}
+#endif  //  _TASK_MICRO_RES
 #endif  //  _TASK_EXTERNAL_TIME
 
 /** Constructor, uses default values for the parameters

--- a/src/TaskSchedulerDeclarations.h
+++ b/src/TaskSchedulerDeclarations.h
@@ -143,7 +143,7 @@ typedef bool (*TaskOnEnable)();
 typedef struct  {
     bool  enabled    : 1;           // indicates that task is enabled or not.
     bool  inonenable : 1;           // indicates that task execution is inside OnEnable method (preventing infinite loops)
-    bool  canceled   : 1;           // indication that tast has been canceled prior to normal end of all iterations or regular call to disable()
+    bool  canceled   : 1;           // indication that task has been canceled prior to normal end of all iterations or regular call to disable()
 #ifdef _TASK_STATUS_REQUEST
     uint8_t  waiting : 2;           // indication if task is waiting on the status request
 #endif
@@ -333,7 +333,7 @@ class Scheduler {
     INLINE void startNow();                             // reset ALL active tasks to immediate execution NOW.
 #endif
     INLINE bool execute();                              // Returns true if none of the tasks' callback methods was invoked (true = idle run)
-    INLINE Task& currentTask() ;                        // DEPRICATED
+    INLINE Task& currentTask() ;                        // DEPRECATED
     INLINE Task* getCurrentTask() ;                     // Returns pointer to the currently active task
     INLINE long timeUntilNextIteration(Task& aTask);    // return number of ms until next iteration of a given Task
 


### PR DESCRIPTION
During compilation the compiler would provide a warning that `_task_micros()` was an unused variable. 

This PR isolates it using the  `_TASK_MICRO_RES` definition.