### PR TITLE
wrapper namespace to avoid class names clash

### DIFF
--- a/examples/Scheduler_example28_NordicNRF52/Scheduler_example28_NordicNRF52.ino
+++ b/examples/Scheduler_example28_NordicNRF52/Scheduler_example28_NordicNRF52.ino
@@ -1,0 +1,97 @@
+/**
+ * This is the same case as in example01 but for NordicNRF52 platform
+ * Core SDK for nRF52 is using same name for the Scheduler objects as TaskScheduler lib does
+ * Due to name clashing compilation fails. We can workaround it by hiding TaskScheduler's lib
+ * objects into namespace and using aliased names for class objects
+ * 
+ * see https://github.com/arkhipenko/TaskScheduler/issues/145 for details
+ */
+
+/** 
+ *  TaskScheduler Test
+ *
+ *  Initially only tasks 1 and 2 are enabled
+ *  Task1 runs every 2 seconds 10 times and then stops
+ *  Task2 runs every 3 seconds indefinitely
+ *  Task1 enables Task3 at its first run
+ *  Task3 run every 5 seconds
+ *  Task1 disables Task3 on its last iteration and changed Task2 to run every 1/2 seconds
+ *  At the end Task2 is the only task running every 1/2 seconds
+ */
+ 
+#include <Arduino.h>
+#include <bluefruit.h>
+
+// here we include a wrapper header for TaskScheduler lib
+#include <TScheduler.hpp>
+
+// Callback methods prototypes
+void t1Callback();
+void t2Callback();
+void t3Callback();
+
+//Tasks
+Task t4();
+Task t1(2000, 10, &t1Callback);
+Task t2(3000, TASK_FOREVER, &t2Callback);
+Task t3(5000, TASK_FOREVER, &t3Callback);
+
+// here we use an aliased name for TaskScheduler's object and avoid name clashing with nRF core
+TaskScheduler runner;
+
+
+void t1Callback() {
+    Serial.print("t1: ");
+    Serial.println(millis());
+    
+    if (t1.isFirstIteration()) {
+      runner.addTask(t3);
+      t3.enable();
+      Serial.println("t1: enabled t3 and added to the chain");
+    }
+    
+    if (t1.isLastIteration()) {
+      t3.disable();
+      runner.deleteTask(t3);
+      t2.setInterval(500);
+      Serial.println("t1: disable t3 and delete it from the chain. t2 interval set to 500");
+    }
+}
+
+void t2Callback() {
+    Serial.print("t2: ");
+    Serial.println(millis());
+  
+}
+
+void t3Callback() {
+    Serial.print("t3: ");
+    Serial.println(millis());
+  
+}
+
+void setup () {
+  Serial.begin(115200);
+  Serial.println("Scheduler TEST");
+  
+  runner.init();
+  Serial.println("Initialized scheduler");
+  
+  runner.addTask(t1);
+  Serial.println("added t1");
+  
+  runner.addTask(t2);
+  Serial.println("added t2");
+
+  delay(5000);
+  
+  t1.enable();
+  Serial.println("Enabled t1");
+  t2.enable();
+  Serial.println("Enabled t2");
+}
+
+
+void loop () {
+  runner.execute();
+}

--- a/src/TScheduler.hpp
+++ b/src/TScheduler.hpp
@@ -1,0 +1,23 @@
+// Cooperative multitasking library for Arduino
+// Copyright (c) 2015-2019 Anatoli Arkhipenko
+
+/*
+    This is a namespace wrapper to avoid collision with frameworks having their
+    own class named Scheduler (i.e. nordicnrf52)
+    include it instead of <TaskScheduler.h> into your sketch and use Class name wrapper - 'TaskScheduler'
+    i.e. 
+    TaskScheduler ts;
+
+*/
+
+#pragma once
+#include <Arduino.h>
+
+namespace TS{
+#include "TaskScheduler.h"
+}
+
+using TaskScheduler = TS::Scheduler;
+using SleepCallback = TS::SleepCallback;
+using Task = TS::Task;
+using StatusRequest = TS::StatusRequest;

--- a/src/TSchedulerDecl.hpp
+++ b/src/TSchedulerDecl.hpp
@@ -1,0 +1,23 @@
+// Cooperative multitasking library for Arduino
+// Copyright (c) 2015-2019 Anatoli Arkhipenko
+
+/*
+    This is a namespace wrapper to avoid collision with frameworks having their
+    own class named Scheduler (i.e. nordicnrf52)
+    include it instead of <TaskSchedulerDeclarations.h> into your sketch and
+    use Class name wrapper - 'TaskScheduler'
+    i.e. 
+    TaskScheduler ts;
+
+*/
+
+#pragma once
+
+namespace TS{
+#include "TaskSchedulerDeclarations.h"
+}
+
+using TaskScheduler = TS::Scheduler;
+using SleepCallback = TS::SleepCallback;
+using Task = TS::Task;
+using StatusRequest = TS::StatusRequest;


### PR DESCRIPTION
suggesting a feasible workaround for #145
a simple wrapper namespace and class aliases to be used with frameworks having clashing class names.
This could also be done in user code, but better to have an example available in the library.

Closes #145