### PR TITLE
Declare tStart and tFinish

### DIFF
--- a/src/TaskScheduler.h
+++ b/src/TaskScheduler.h
@@ -1341,13 +1341,16 @@ bool Scheduler::execute() {
     bool     idleRun = true;
     unsigned long m, i;  // millis, interval;
 
+#ifdef _TASK_SLEEP_ON_IDLE_RUN
+    unsigned long tFinish;
+    unsigned long tStart;
+#endif  // _TASK_SLEEP_ON_IDLE_RUN
+
 #if defined(_TASK_TIMECRITICAL)
     unsigned long tPassStart;
     unsigned long tTaskStart, tTaskFinish;
 
 #ifdef _TASK_SLEEP_ON_IDLE_RUN
-    unsigned long tFinish;
-    unsigned long tStart;
     unsigned long tIdleStart = 0;
 #endif  // _TASK_SLEEP_ON_IDLE_RUN
 


### PR DESCRIPTION
the variables `tStart` and `tFinish` are required if sleep support is enabled, independent of `_TASK_TIMECRITICAL`. however, they were guarded by `_TASK_TIMECRITICAL` as well.

this bug prevents building `Scheduler_example19_Dynamic_Tasks_SelfDestruct.ino` in particular.