### PR TITLE
delete manually disabled self-destruct tasks

### DIFF
--- a/examples/Scheduler_example19_Dynamic_Tasks_SelfDestruct/Scheduler_example19_Dynamic_Tasks_SelfDestruct.ino
+++ b/examples/Scheduler_example19_Dynamic_Tasks_SelfDestruct/Scheduler_example19_Dynamic_Tasks_SelfDestruct.ino
@@ -42,6 +42,8 @@ void GC();
 // Statis task
 Task tMain(100 * TASK_MILLISECOND, 100, &MainLoop, &ts, true);
 
+long maxIterations = 0;
+
 void Iteration();
 bool OnEnable();
 void OnDisable();
@@ -58,6 +60,7 @@ void MainLoop() {
     // Generating another task
     long p = random(100, 5001); // from 100 ms to 5 seconds
     long j = random(1, 11); // from 1 to 10 iterations)
+    maxIterations = (j>maxIterations) ? j : maxIterations;
     Task *t = new Task(p, j, Iteration, &ts, false, OnEnable, OnDisable, true); // enable self-destruct
 
     Serial.print(F("Generated a new task:\t")); Serial.print(t->getId()); Serial.print(F("\tInt, Iter = \t"));
@@ -79,6 +82,11 @@ void Iteration() {
   Serial.print("Task N"); Serial.print(t.getId()); Serial.print(F("\tcurrent iteration: "));
   int i = t.getRunCounter();
   Serial.println(i);
+
+  if (i + 1 >= maxIterations) {
+    t.disable();
+    maxIterations *= 2; // self-disable exactly one task
+  }
 }
 
 bool OnEnable() {

--- a/src/TaskScheduler.h
+++ b/src/TaskScheduler.h
@@ -1547,6 +1547,9 @@ bool Scheduler::execute() {
 #endif  // _TASK_TIMECRITICAL
 
             }
+#ifdef _TASK_SELF_DESTRUCT
+            else if ( iCurrent->iStatus.sd_request ) delete iCurrent;
+#endif  //  #ifdef _TASK_SELF_DESTRUCT
         } while (0);    //guaranteed single run - allows use of "break" to exit
 
         iCurrent = nextTask;


### PR DESCRIPTION
adjusts an example to disable a single task before it runs out of iterations. the task disables itself. without the fix in `TaskScheduler.h`, one can observe a memory leak, as the task which disabled itself is not deleted.

the TaskScheduler is adjusted to check the self-destruct request flag of disabled tasks and to delete such tasks.

### output of original example
```
Free mem=354580 No of tasks=0

        No of tasks=0
        Free mem=354580
```

### output of modified example without fix:
```
Free mem=354572 No of tasks=0

        No of tasks=0
        Free mem=354488
```

### output of modified example with fix:
```
Free mem=354572 No of tasks=0

        No of tasks=0
        Free mem=354572
```