### PR TITLE
fix deletion of self-destruct tasks in disableAll()

### DIFF
--- a/examples/Scheduler_example19_Dynamic_Tasks_SelfDestruct/Scheduler_example19_Dynamic_Tasks_SelfDestruct.ino
+++ b/examples/Scheduler_example19_Dynamic_Tasks_SelfDestruct/Scheduler_example19_Dynamic_Tasks_SelfDestruct.ino
@@ -114,7 +114,8 @@ void setup() {
 
 void loop() {
   ts.execute();
-  if ( millis() > 5000 && noOfTasks == 0 ) {
+  if ( millis() > 5000 && noOfTasks == 5 ) {
+      ts.disableAll();
       Serial.print(F("\tFree mem=")); Serial.println(freeMemory());
       while(1);
   }

--- a/src/TaskScheduler.h
+++ b/src/TaskScheduler.h
@@ -1190,7 +1190,7 @@ void Scheduler::disableAll() {
         next = current->iNext;
         current->disable();
 #ifdef _TASK_SELF_DESTRUCT
-        if ( current->iStatus.sd_request ) delete iCurrent;
+        if ( current->iStatus.sd_request ) delete current;
 #endif  //  #ifdef _TASK_SELF_DESTRUCT
         current = next;
     }


### PR DESCRIPTION
instead of deleting `iCurrent` multiple times, the task which was just disabled and has the self-destruct request flag set, shall be deleted.

adjust the respective example to disable the remaining 5 tasks using `disableAll()`, which then shows that not all memory is freed.